### PR TITLE
Reduced console output during debug level 2

### DIFF
--- a/gk-shp.c
+++ b/gk-shp.c
@@ -358,6 +358,7 @@ usage:      usage(prog, 0);
   }
 
   // process entitites (shapes) in input shapefile
+  int nPercentBefore = -1;
   warn = 1;
   for (nEntity = 0; nEntity < nEntities; nEntity++) {
     psShape = SHPReadObject(iSHP, nEntity);
@@ -367,6 +368,7 @@ usage:      usage(prog, 0);
       break;
     }
 
+    int nPercent = (long)nEntity*10000/nEntities;
     if (debug > 2) {
       fprintf(stderr, T("Shape: %d (%s), Vertices: %d, Parts: %d\n"),
               nEntity, SHPTypeName(psShape->nSHPType),
@@ -384,9 +386,8 @@ usage:      usage(prog, 0);
             psShape->dfXMax, psShape->dfYMax, psShape->dfZMax);
       }
     }
-    else if (debug == 2)
-      fprintf(stderr, T("Shape: %d (%.2f%%)\r"), nEntity,
-              (double)nEntity/(double)nEntities*100.0);
+    else if (debug == 2 && (nPercent > nPercentBefore || nEntity == nEntities))
+      fprintf(stderr, T("Shape: %d (%.2f%%)\r"), nEntity, (double)nPercent/100.0);
 
     if (psShape->nParts > 0 && psShape->panPartStart[0] != 0)
       fprintf(stderr, T("%s: panPartStart[0] = %d, not zero as expected\n"),
@@ -487,6 +488,8 @@ usage:      usage(prog, 0);
       memcpy(oTuple, iTuple, iDBF->nRecordLength);
       DBFWriteTuple(oDBF, oDBF->nRecords, oTuple);
     }
+
+    nPercentBefore = nPercent;
   } // for each Entity
 
   clock_gettime(CLOCK_REALTIME, &stop);


### PR DESCRIPTION
...by writing status only once every 0.01% completion instead of on every shape

Eg: during 1.2 GB RABA shapefile processing it now outputs to console only 200kB instead of 37MB, which is much easier to track remotely (nohup, tail...) and slightly faster.
